### PR TITLE
Add percepção game with menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
 </div>
 </div>
 </header>
+<nav class="main-nav"><ul><li><a href="index.html">Início</a></li><li><a href="percepcao.html">Percepção</a></li></ul></nav>
 
 
 <main class="wp-block-group is-layout-flow wp-block-group-is-layout-flow" style="margin-top:0px;margin-bottom:0px">

--- a/percepcao.html
+++ b/percepcao.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Percepção - Nikolas Yuri</title>
+    <link rel="stylesheet" href="extendable-style.css" />
+    <link rel="stylesheet" href="responsive.css" />
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div class="wp-site-blocks">
+<header class="wp-block-template-part">
+<div class="wp-block-group alignfull has-global-padding is-layout-constrained wp-block-group-is-layout-constrained" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+<div class="wp-block-group alignwide is-content-justification-space-between is-nowrap is-layout-flex wp-container-core-group-is-layout-cb46ffcb wp-block-group-is-layout-flex">
+<div class="wp-block-group is-nowrap is-layout-flex wp-container-core-group-is-layout-f1189ed3 wp-block-group-is-layout-flex"><div class="is-default-size wp-block-site-logo"><a href="index.html" class="custom-logo-link" rel="home" aria-current="page"><img width="150" height="150" src="https://nikolasyuri.com.br/wp-content/uploads/2025/06/Logo-copy-Background-Removed.png" class="custom-logo" alt="Nikolas Yuri" decoding="async" /></a></div>
+<h1 style="text-transform:uppercase;" class="wp-block-site-title has-medium-font-size"><a href="index.html" target="_self" rel="home" aria-current="page">Nikolas Yuri</a></h1></div>
+<div class="wp-block-group is-nowrap is-layout-flex wp-container-core-group-is-layout-6c531013 wp-block-group-is-layout-flex"></div>
+</div>
+</div>
+</header>
+<nav class="main-nav">
+  <ul>
+    <li><a href="index.html">Início</a></li>
+    <li><a href="percepcao.html">Percepção</a></li>
+  </ul>
+</nav>
+<main class="game-container">
+    <h2>Treino de Percepção</h2>
+    <p id="question"></p>
+    <button id="play-sound">Tocar acorde</button>
+    <div id="options">
+        <button data-type="Maior">Maior</button>
+        <button data-type="Menor">Menor</button>
+        <button data-type="Diminuto">Diminuto</button>
+    </div>
+    <p id="feedback"></p>
+</main>
+</div>
+<script src="percepcao.js"></script>
+</body>
+</html>

--- a/percepcao.js
+++ b/percepcao.js
@@ -1,0 +1,54 @@
+const chords = [
+  { name: 'Maior', intervals: [0, 4, 7] },
+  { name: 'Menor', intervals: [0, 3, 7] },
+  { name: 'Diminuto', intervals: [0, 3, 6] }
+];
+
+const totalQuestions = 5;
+let currentQuestion = 0;
+let score = 0;
+let currentChord = chords[0];
+
+function playChord(intervals, root = 261.63) {
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  const context = new AudioCtx();
+  const now = context.currentTime;
+  intervals.forEach(i => {
+    const osc = context.createOscillator();
+    osc.frequency.value = root * Math.pow(2, i / 12);
+    osc.connect(context.destination);
+    osc.start(now);
+    osc.stop(now + 1.2);
+  });
+}
+
+function nextQuestion() {
+  if (currentQuestion >= totalQuestions) {
+    document.getElementById('question').textContent = `Fim de jogo! Você acertou ${score} de ${totalQuestions}.`;
+    document.getElementById('options').style.display = 'none';
+    document.getElementById('play-sound').style.display = 'none';
+    return;
+  }
+  document.getElementById('feedback').textContent = '';
+  currentChord = chords[Math.floor(Math.random() * chords.length)];
+  document.getElementById('question').textContent = `Questão ${currentQuestion + 1} de ${totalQuestions}`;
+}
+
+document.getElementById('play-sound').addEventListener('click', () => {
+  playChord(currentChord.intervals);
+});
+
+document.querySelectorAll('#options button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    if (btn.dataset.type === currentChord.name) {
+      score++;
+      document.getElementById('feedback').textContent = 'Correto!';
+    } else {
+      document.getElementById('feedback').textContent = `Errado! Era ${currentChord.name}.`;
+    }
+    currentQuestion++;
+    setTimeout(nextQuestion, 1000);
+  });
+});
+
+window.addEventListener('load', nextQuestion);

--- a/style.css
+++ b/style.css
@@ -107,3 +107,17 @@ img.wp-smiley, img.emoji {
 @font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('https://nikolasyuri.com.br/wp-content/themes/extendable/assets/fonts/source-serif-pro/source-serif-pro.woff2') format('woff2');font-stretch:normal;}
 @font-face{font-family:"Space Mono";font-style:normal;font-weight:400;font-display:fallback;src:url('https://nikolasyuri.com.br/wp-content/themes/extendable/assets/fonts/space-mono/space-mono-regular.woff2') format('woff2');}
 @font-face{font-family:"Space Mono";font-style:normal;font-weight:700;font-display:fallback;src:url('https://nikolasyuri.com.br/wp-content/themes/extendable/assets/fonts/space-mono/space-mono-bold.woff2') format('woff2');}
+
+/* Navigation menu */
+.main-nav {
+  background:#333;
+  text-align:center;
+  padding:10px;
+}
+.main-nav ul { list-style:none; margin:0; padding:0; display:flex; justify-content:center; gap:20px; }
+.main-nav a { color:#fff; text-decoration:none; font-weight:bold; }
+.main-nav a:hover { text-decoration:underline; }
+
+/* Game styles */
+.game-container { text-align:center; padding:20px; }
+.game-container button { margin:5px; padding:10px 20px; }


### PR DESCRIPTION
## Summary
- add navigation menu linking to new `Percepção` page
- create `Percepção` page with simple ear training game
- implement game logic to recognize chord types
- style navigation and game section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a50c977748331a4ea5f51eccf6b9f