### PR TITLE
Fix mobile audio in perception page

### DIFF
--- a/percepcao.js
+++ b/percepcao.js
@@ -9,9 +9,13 @@ let currentQuestion = 0;
 let score = 0;
 let currentChord = chords[0];
 
+const AudioCtx = window.AudioContext || window.webkitAudioContext;
+const context = new AudioCtx();
+
 function playChord(intervals, root = 261.63) {
-  const AudioCtx = window.AudioContext || window.webkitAudioContext;
-  const context = new AudioCtx();
+  if (context.state === 'suspended') {
+    context.resume();
+  }
   const now = context.currentTime;
   intervals.forEach(i => {
     const osc = context.createOscillator();


### PR DESCRIPTION
## Summary
- reuse a single AudioContext instance for the perception page
- resume the context on user interaction

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684a5395c77c8331912b0943f4c417c5