### PR TITLE
Fix video section layout and icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,11 +437,13 @@
 <div class="wp-block-group alignfull has-background-background-color has-background has-global-padding is-content-justification-center is-layout-constrained wp-container-core-group-is-layout-ec6b92b3 wp-block-group-is-layout-constrained" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--30)">
 <div class="wp-block-group alignwide is-vertical is-layout-flex wp-container-core-group-is-layout-fe9cc265 wp-block-group-is-layout-flex">
 <div class="wp-block-group alignwide has-global-padding is-content-justification-center is-layout-constrained wp-container-core-group-is-layout-8b4c372c wp-block-group-is-layout-constrained">
+<div class="feedback-section">
 <h2 class="wp-block-heading has-large-font-size" style="text-align:center">Feedback dos alunos</h2>
 
 
 
 <p style="margin-top:16px;text-align:center">Feedbacks que recebo de alguns alunos.</p>
+</div>
 </div>
 </div>
 
@@ -455,7 +457,7 @@
                 <track kind="captions" srclang="pt" label="Legenda" src="maria-tereza.vtt">
             </video>
             <button class="back-button" aria-label="Voltar"></button>
-            <button class="play-button" aria-label="Play"></button>
+            <button class="play-button" aria-label="Play"><img src="play.svg" alt=""></button>
         </div>
         <figcaption>
             <span>Maria Tereza – 9 Anos | Legenda</span>
@@ -469,7 +471,7 @@
                 <track kind="captions" srclang="pt" label="Legenda" src="recomendacao-paul.vtt">
             </video>
             <button class="back-button" aria-label="Voltar"></button>
-            <button class="play-button" aria-label="Play"></button>
+            <button class="play-button" aria-label="Play"><img src="play.svg" alt=""></button>
         </div>
         <figcaption>
             <span>Paul Timitch | Legenda</span>
@@ -483,7 +485,7 @@
                 <track kind="captions" srclang="pt" label="Legenda" src="video-flavio-pedron.vtt">
             </video>
             <button class="back-button" aria-label="Voltar"></button>
-            <button class="play-button" aria-label="Play"></button>
+            <button class="play-button" aria-label="Play"><img src="play.svg" alt=""></button>
         </div>
         <figcaption>
             <span>Flavio Pedron | Legenda</span>
@@ -497,7 +499,7 @@
                 <track kind="captions" srclang="pt" label="Legenda" src="video-bernardo.vtt">
             </video>
             <button class="back-button" aria-label="Voltar"></button>
-            <button class="play-button" aria-label="Play"></button>
+            <button class="play-button" aria-label="Play"><img src="play.svg" alt=""></button>
         </div>
         <figcaption>
             <span>Bernardo | Legenda</span>

--- a/play.svg
+++ b/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
+  <path d="M3 2v20l19-10L3 2z"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -141,6 +141,7 @@ img.wp-smiley, img.emoji {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    object-position: top;
     border-radius: 10px;
 }
 .student-video .play-button,
@@ -162,12 +163,9 @@ img.wp-smiley, img.emoji {
     height: 60px;
     transform: translate(-50%, -50%);
 }
-.student-video .play-button::before {
-    content: '';
-    border-style: solid;
-    border-width: 12px 0 12px 18px;
-    border-color: transparent transparent transparent #fff;
-    margin-left: 3px;
+.student-video .play-button img {
+    width: 24px;
+    height: 24px;
 }
 .student-video .back-button {
     top: 10px;
@@ -189,9 +187,10 @@ img.wp-smiley, img.emoji {
     align-items: center;
 }
 .student-video figcaption img {
-    width: 24px;
-    height: 24px;
+    width: 16px;
+    height: 16px;
     margin-top: 4px;
+    display: inline-block;
 }
 
 .student-gallery {
@@ -207,5 +206,9 @@ img.wp-smiley, img.emoji {
     .student-gallery .student-video {
         flex-basis: 100%;
     }
+}
+
+.feedback-section {
+    text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- improve student video layout
- use play.svg and ensure instagram logo is small
- center feedback section title and text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684abfd9bfe483318df8fcd24f3143d2