### PR TITLE
Update play icon style

### DIFF
--- a/play.svg
+++ b/play.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#E4405F">
   <path d="M3 2v20l19-10L3 2z"/>
 </svg>

--- a/style.css
+++ b/style.css
@@ -144,6 +144,10 @@ img.wp-smiley, img.emoji {
     object-position: top;
     border-radius: 10px;
 }
+.student-video video::-webkit-media-controls-start-playback-button {
+    display: none;
+    -webkit-appearance: none;
+}
 .student-video .play-button,
 .student-video .back-button {
     position: absolute;


### PR DESCRIPTION
## Summary
- update play.svg fill color to match Instagram icon
- hide native video play icon overlay to prevent duplication

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_684ac3eb19708331b5f2c9b2c7f464f5