### PR TITLE
Improve perception game features

### DIFF
--- a/percepcao.html
+++ b/percepcao.html
@@ -27,14 +27,15 @@
 </nav>
 <main class="game-container">
     <h2>Treino de Percepção</h2>
+    <p id="timer">Tempo: 0s</p>
     <p id="question"></p>
     <button id="play-sound">Tocar acorde</button>
     <div id="options">
         <button data-type="Maior">Maior</button>
         <button data-type="Menor">Menor</button>
-        <button data-type="Diminuto">Diminuto</button>
     </div>
     <p id="feedback"></p>
+    <p id="result"></p>
 </main>
 </div>
 <script src="percepcao.js"></script>

--- a/percepcao.js
+++ b/percepcao.js
@@ -1,16 +1,30 @@
 const chords = [
   { name: 'Maior', intervals: [0, 4, 7] },
-  { name: 'Menor', intervals: [0, 3, 7] },
-  { name: 'Diminuto', intervals: [0, 3, 6] }
+  { name: 'Menor', intervals: [0, 3, 7] }
 ];
 
-const totalQuestions = 5;
+const totalQuestions = 10;
 let currentQuestion = 0;
 let score = 0;
 let currentChord = chords[0];
+let startTime;
+let timerInterval;
 
 const AudioCtx = window.AudioContext || window.webkitAudioContext;
 const context = new AudioCtx();
+
+function startTimer() {
+  startTime = Date.now();
+  timerInterval = setInterval(() => {
+    const seconds = Math.floor((Date.now() - startTime) / 1000);
+    document.getElementById('timer').textContent = `Tempo: ${seconds}s`;
+  }, 1000);
+}
+
+function stopTimer() {
+  clearInterval(timerInterval);
+  return Math.floor((Date.now() - startTime) / 1000);
+}
 
 function playChord(intervals, root = 261.63) {
   if (context.state === 'suspended') {
@@ -28,14 +42,30 @@ function playChord(intervals, root = 261.63) {
 
 function nextQuestion() {
   if (currentQuestion >= totalQuestions) {
-    document.getElementById('question').textContent = `Fim de jogo! Você acertou ${score} de ${totalQuestions}.`;
-    document.getElementById('options').style.display = 'none';
-    document.getElementById('play-sound').style.display = 'none';
+    finishGame();
     return;
   }
   document.getElementById('feedback').textContent = '';
   currentChord = chords[Math.floor(Math.random() * chords.length)];
   document.getElementById('question').textContent = `Questão ${currentQuestion + 1} de ${totalQuestions}`;
+}
+
+function finishGame() {
+  const totalTime = stopTimer();
+  const percentage = Math.round((score / totalQuestions) * 100);
+  document.getElementById('question').textContent = 'Fim de jogo!';
+  const resultEl = document.getElementById('result');
+  resultEl.textContent = `Você acertou ${score} de ${totalQuestions} (${percentage}%) em ${totalTime}s.`;
+  resultEl.style.color = percentage >= 60 ? 'green' : 'red';
+  document.getElementById('options').style.display = 'none';
+  document.getElementById('play-sound').style.display = 'none';
+}
+
+function startGame() {
+  currentQuestion = 0;
+  score = 0;
+  startTimer();
+  nextQuestion();
 }
 
 document.getElementById('play-sound').addEventListener('click', () => {
@@ -46,13 +76,13 @@ document.querySelectorAll('#options button').forEach(btn => {
   btn.addEventListener('click', () => {
     if (btn.dataset.type === currentChord.name) {
       score++;
-      document.getElementById('feedback').textContent = 'Correto!';
+      document.getElementById('feedback').textContent = `Correto! O acorde era ${currentChord.name}.`;
     } else {
-      document.getElementById('feedback').textContent = `Errado! Era ${currentChord.name}.`;
+      document.getElementById('feedback').textContent = `Errado! O acorde era ${currentChord.name}.`;
     }
     currentQuestion++;
     setTimeout(nextQuestion, 1000);
   });
 });
 
-window.addEventListener('load', nextQuestion);
+window.addEventListener('load', startGame);

--- a/style.css
+++ b/style.css
@@ -124,6 +124,8 @@ img.wp-smiley, img.emoji {
 /* Game styles */
 .game-container { text-align:center; padding:20px; }
 .game-container button { margin:5px; padding:10px 20px; }
+.game-container #timer { font-weight:bold; margin-bottom:10px; }
+.game-container #result { font-size:1.2em; margin-top:20px; }
 
 /* Student video gallery */
 .student-video {


### PR DESCRIPTION
## Summary
- add timer and result section in perception HTML
- expand JS game to 10 questions and remove diminished chords
- display running timer, final stats and color-coded result
- style timer and result elements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aca4b15d8833193461aed1644a96b