### PR TITLE
Add progress bar and audio fix

### DIFF
--- a/percepcao.html
+++ b/percepcao.html
@@ -28,11 +28,12 @@
 <main class="game-container">
     <h2>Treino de Percepção</h2>
     <p id="timer">Tempo: 0s</p>
+    <div id="timer-bar"><div id="timer-progress"></div></div>
     <p id="question"></p>
-    <button id="play-sound">Tocar acorde</button>
+    <button id="play-sound" class="wp-element-button has-background">Tocar acorde</button>
     <div id="options">
-        <button data-type="Maior">Maior</button>
-        <button data-type="Menor">Menor</button>
+        <button data-type="Maior" class="wp-element-button">Maior</button>
+        <button data-type="Menor" class="wp-element-button">Menor</button>
     </div>
     <p id="feedback"></p>
     <p id="result"></p>

--- a/percepcao.js
+++ b/percepcao.js
@@ -10,14 +10,27 @@ let currentChord = chords[0];
 let startTime;
 let timerInterval;
 
-const AudioCtx = window.AudioContext || window.webkitAudioContext;
-const context = new AudioCtx();
+let context;
+function getContext() {
+  if (!context) {
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    context = new AudioCtx();
+  }
+  if (context.state === 'suspended') {
+    context.resume();
+  }
+  return context;
+}
+
+const progressEl = document.getElementById('timer-progress');
 
 function startTimer() {
   startTime = Date.now();
   timerInterval = setInterval(() => {
     const seconds = Math.floor((Date.now() - startTime) / 1000);
     document.getElementById('timer').textContent = `Tempo: ${seconds}s`;
+    const progress = Math.min(seconds, 60) / 60 * 100;
+    progressEl.style.width = progress + '%';
   }, 1000);
 }
 
@@ -27,14 +40,12 @@ function stopTimer() {
 }
 
 function playChord(intervals, root = 261.63) {
-  if (context.state === 'suspended') {
-    context.resume();
-  }
-  const now = context.currentTime;
+  const ctx = getContext();
+  const now = ctx.currentTime;
   intervals.forEach(i => {
-    const osc = context.createOscillator();
+    const osc = ctx.createOscillator();
     osc.frequency.value = root * Math.pow(2, i / 12);
-    osc.connect(context.destination);
+    osc.connect(ctx.destination);
     osc.start(now);
     osc.stop(now + 1.2);
   });

--- a/style.css
+++ b/style.css
@@ -125,6 +125,8 @@ img.wp-smiley, img.emoji {
 .game-container { text-align:center; padding:20px; }
 .game-container button { margin:5px; padding:10px 20px; }
 .game-container #timer { font-weight:bold; margin-bottom:10px; }
+#timer-bar { width:100%; height:10px; background:#eee; border-radius:5px; overflow:hidden; margin-bottom:15px; }
+#timer-progress { height:100%; width:0; background:#007cba; transition:width 1s linear; }
 .game-container #result { font-size:1.2em; margin-top:20px; }
 
 /* Student video gallery */


### PR DESCRIPTION
## Summary
- make perception game buttons follow site style and add timer bar
- animate timer bar and initialize WebAudio on user action

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684accf0dab083319cf1374b45469ad4