### PR TITLE
Improve perception game intro and timer

### DIFF
--- a/percepcao.html
+++ b/percepcao.html
@@ -27,16 +27,33 @@
 </nav>
 <main class="game-container">
     <h2>Treino de Percepção</h2>
-    <p id="timer">Tempo: 0s</p>
-    <div id="timer-bar"><div id="timer-progress"></div></div>
-    <p id="question"></p>
-    <button id="play-sound" class="wp-element-button has-background">Tocar acorde</button>
-    <div id="options">
-        <button data-type="Maior" class="wp-element-button">Maior</button>
-        <button data-type="Menor" class="wp-element-button">Menor</button>
+    <div id="intro">
+        <p>🎵 Bem-vindo ao Jogo de Percepção Musical! 🎵</p>
+        <p>Neste jogo, você vai treinar seu ouvido para reconhecer acordes maiores e menores.
+Os acordes maiores costumam soar claros, alegres e abertos, enquanto os acordes menores têm um som mais triste, escuro e introspectivo.
+Seu desafio é simples: ouça atentamente e descubra se o acorde é maior ou menor.</p>
+        <p>⏱️ O tempo de cada partida será contado, assim você pode acompanhar sua evolução e tentar melhorar sua agilidade a cada nova tentativa.</p>
+        <p>🧠 Ao final de 10 perguntas, você verá o seu resultado:</p>
+        <ul>
+            <li>Quantos acordes você acertou</li>
+            <li>Quantos errou</li>
+            <li>E uma dica personalizada do que estudar para melhorar ainda mais sua percepção musical!</li>
+        </ul>
+        <p>Prepare seu ouvido, respire fundo e... vamos começar! 🎧</p>
+        <button id="start-game" class="wp-element-button">Iniciar</button>
     </div>
-    <p id="feedback"></p>
-    <p id="result"></p>
+    <div id="game-area" style="display:none;">
+        <p id="timer">Tempo: 0s</p>
+        <div id="timer-bar"><div id="timer-progress"></div></div>
+        <p id="question"></p>
+        <button id="play-sound" class="wp-element-button has-background">Tocar acorde</button>
+        <div id="options">
+            <button data-type="Maior" class="wp-element-button">Maior</button>
+            <button data-type="Menor" class="wp-element-button">Menor</button>
+        </div>
+        <p id="feedback"></p>
+        <p id="result"></p>
+    </div>
 </main>
 </div>
 <script src="percepcao.js"></script>

--- a/percepcao.js
+++ b/percepcao.js
@@ -27,10 +27,20 @@ const progressEl = document.getElementById('timer-progress');
 function startTimer() {
   startTime = Date.now();
   timerInterval = setInterval(() => {
-    const seconds = Math.floor((Date.now() - startTime) / 1000);
-    document.getElementById('timer').textContent = `Tempo: ${seconds}s`;
-    const progress = Math.min(seconds, 60) / 60 * 100;
+    const elapsed = Math.floor((Date.now() - startTime) / 1000);
+    const minutes = Math.floor(elapsed / 60);
+    const seconds = elapsed % 60;
+    const progress = (seconds / 60) * 100;
+
     progressEl.style.width = progress + '%';
+
+    if (minutes > 0) {
+      const minLabel = minutes > 1 ? 'minutos' : 'minuto';
+      document.getElementById('timer').textContent =
+        `Tempo: ${minutes}:${seconds.toString().padStart(2, '0')} ${minLabel}`;
+    } else {
+      document.getElementById('timer').textContent = `Tempo: ${seconds}s`;
+    }
   }, 1000);
 }
 
@@ -73,6 +83,8 @@ function finishGame() {
 }
 
 function startGame() {
+  document.getElementById('intro').style.display = 'none';
+  document.getElementById('game-area').style.display = 'block';
   currentQuestion = 0;
   score = 0;
   startTimer();
@@ -96,4 +108,4 @@ document.querySelectorAll('#options button').forEach(btn => {
   });
 });
 
-window.addEventListener('load', startGame);
+document.getElementById('start-game').addEventListener('click', startGame);


### PR DESCRIPTION
## Summary
- add intro instructions and start button to the perception game
- start game on button click
- reset progress bar every minute and show minutes/seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ada3defc48331a75b2582dabe1ac3