### PR TITLE
Fix mobile audio and timer color

### DIFF
--- a/percepcao.js
+++ b/percepcao.js
@@ -113,4 +113,7 @@ document.querySelectorAll('#options button').forEach(btn => {
   });
 });
 
-document.getElementById('start-game').addEventListener('click', startGame);
+document.getElementById('start-game').addEventListener('click', () => {
+  getContext(); // unlock audio on mobile devices
+  startGame();
+});

--- a/style.css
+++ b/style.css
@@ -134,6 +134,7 @@ img.wp-smiley, img.emoji {
     padding: 20px;
     border-radius: 10px;
     margin-bottom: 20px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 .game-container #game-area {
     max-width: 100%;
@@ -142,7 +143,7 @@ img.wp-smiley, img.emoji {
 .game-container button { margin:5px; padding:10px 20px; }
 .game-container #timer { font-weight:bold; margin-bottom:10px; }
 #timer-bar { width:100%; height:10px; background:#eee; border-radius:5px; overflow:hidden; margin-bottom:15px; }
-#timer-progress { height:100%; width:0; background:#007cba; transition:width 1s linear; }
+#timer-progress { height:100%; width:0; background:#28a745; transition:width 1s linear; }
 .game-container #result { font-size:1.2em; margin-top:20px; }
 
 /* Student video gallery */


### PR DESCRIPTION
## Summary
- unlock Web Audio API on mobile when starting the perception game
- style game instructions with a white box and add drop shadow
- change timer progress color to green

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aefcc858c8331b38aacf69c1aea8c