### PR TITLE
Add difficulty selection screen

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -6,6 +6,14 @@
   border-radius: 4px;
   cursor: pointer;
 }
+#select-difficulty {
+  background-color: #28a745;
+  color: #fff;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
 .sun-icon {
   color: #FFD700;
 }
@@ -13,6 +21,33 @@
 #level-select button.selected {
   background-color: #28a745;
   color: #fff;
+}
+
+.level-btn {
+  margin: 5px;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.easy {
+  background-color: #28a745;
+  color: #fff;
+}
+
+.medium {
+  background-color: #ffc107;
+  color: #000;
+}
+
+.hard {
+  background-color: #dc3545;
+  color: #fff;
+}
+
+.level-description {
+  margin-bottom: 10px;
 }
 
 #end-buttons {

--- a/percepcao.html
+++ b/percepcao.html
@@ -36,13 +36,17 @@ Seu desafio é simples: ouça atentamente e descubra se o acorde é maior ou men
         <p>⏱️ O tempo de cada partida será contado, assim você pode acompanhar sua evolução e tentar melhorar sua agilidade a cada nova tentativa.</p>
         <p>🧠 Ao final de 10 perguntas, você verá o seu resultado.</p>
         <p>Prepare seu ouvido, respire fundo e... vamos começar! 🎧</p>
-        <div id="level-select">
+        <button id="select-difficulty" class="wp-element-button">Selecionar dificuldade</button>
+        <div id="level-select" style="display:none;">
             <p>Escolha o nível do exercício:</p>
-            <button data-level="facil" class="wp-element-button">Fácil</button>
-            <button data-level="medio" class="wp-element-button">Médio</button>
-            <button data-level="dificil" class="wp-element-button">Difícil</button>
+            <button data-level="facil" class="wp-element-button level-btn easy">Fácil</button>
+            <p class="level-description">Serão tocados somente acordes maiores e menores.</p>
+            <button data-level="medio" class="wp-element-button level-btn medium">Médio</button>
+            <p class="level-description">Serão tocados acordes Maiores, Menores, Diminutos e Aumentados.</p>
+            <button data-level="dificil" class="wp-element-button level-btn hard">Difícil</button>
+            <p class="level-description">Os acordes poderão ser tétrades também, serão tocados acordes Maiores, Menores, Diminutos, Aumentados, Maiores com 7M, Maiores com 7m, Menores com 7M e Menores com 7m.</p>
+            <button id="start-game" class="wp-element-button" style="display:none;">Iniciar</button>
         </div>
-        <button id="start-game" class="wp-element-button">Iniciar</button>
     </div>
     <div id="game-area" style="display:none;">
         <p id="timer">Tempo: 0s</p>

--- a/percepcao.js
+++ b/percepcao.js
@@ -139,16 +139,22 @@ document.querySelectorAll('#options button').forEach(btn => {
   });
 });
 
+document.getElementById('select-difficulty').addEventListener('click', () => {
+  document.getElementById('level-select').style.display = 'block';
+  document.getElementById('select-difficulty').style.display = 'none';
+});
+
 document.getElementById('start-game').addEventListener('click', () => {
   getContext(); // unlock audio on mobile devices
   startGame();
 });
 
-document.querySelectorAll('#level-select button').forEach(btn => {
+document.querySelectorAll('#level-select .level-btn').forEach(btn => {
   btn.addEventListener('click', () => {
     currentLevel = btn.dataset.level;
-    document.querySelectorAll('#level-select button').forEach(b => b.classList.remove('selected'));
+    document.querySelectorAll('#level-select .level-btn').forEach(b => b.classList.remove('selected'));
     btn.classList.add('selected');
+    document.getElementById('start-game').style.display = 'block';
   });
 });
 
@@ -160,4 +166,8 @@ document.getElementById('change-level').addEventListener('click', () => {
   document.getElementById('game-area').style.display = 'none';
   document.getElementById('intro').style.display = 'block';
   document.getElementById('end-buttons').style.display = 'none';
+  document.getElementById('select-difficulty').style.display = 'block';
+  document.getElementById('level-select').style.display = 'none';
+  document.getElementById('start-game').style.display = 'none';
+  document.querySelectorAll('#level-select .level-btn').forEach(b => b.classList.remove('selected'));
 });


### PR DESCRIPTION
## Summary
- add difficulty explanations and colors to `percepcao.html`
- style difficulty buttons with colors
- make difficulty selection appear only after clicking a new button
- display Start button only after a level is picked

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c3a941e788331af86a81ee00fe60c