### PR TITLE
Fix percepcao level colors

### DIFF
--- a/percepcao.html
+++ b/percepcao.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Treino de Percepção</title>
+  <link rel="stylesheet" href="custom.css" />
   <style>
     :root {
       --verde: #1f5d3e;
@@ -135,7 +136,7 @@
         </div>
         <div id="next-level" class="seta-direita nav-btn">&#9654;</div>
       </div>
-      <button id="start-game" class="wp-element-button" style="background-color: var(--verde)">Iniciar</button>
+      <button id="start-game" class="wp-element-button">Iniciar</button>
     </div>
     <button id="select-difficulty" style="display:none;"></button>
   </div>


### PR DESCRIPTION
## Summary
- include custom styles on percepcao page
- remove inline styling from start button so selected color applies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c8d9383b0833197c3e58ea8af0d45