### PR TITLE
Ajusta estilos da página de percepção

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -31,22 +31,22 @@
 }
 
 .easy {
-  background-color: #1f5d3e;
+  background-color: #1f5d3e !important;
   color: #fff;
 }
 
 .medium {
-  background-color: #c7791a;
+  background-color: #c7791a !important;
   color: #fff;
 }
 
 .hard {
-  background-color: #a92626;
+  background-color: #a92626 !important;
   color: #fff;
 }
 
 .advanced {
-  background-color: #6d28d9;
+  background-color: #6d28d9 !important;
   color: #fff;
 }
 
@@ -90,6 +90,8 @@
   align-items: center;
   justify-content: center;
   margin: 10px auto;
+  background-color: #facc15;
+  color: #000;
 }
 
 #play-sound img {

--- a/percepcao.html
+++ b/percepcao.html
@@ -35,9 +35,9 @@
     }
 
     .nivel-box {
-      backdrop-filter: blur(12px);
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.2);
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      backdrop-filter: blur(10px);
       border-radius: 1rem;
       padding: 2rem;
       text-align: center;
@@ -93,7 +93,7 @@
     .progresso {
       width: 200px;
       height: 8px;
-      background: var(--claro);
+      background: #3a3a3a;
       border-radius: 5px;
       overflow: hidden;
     }
@@ -121,6 +121,27 @@
       margin: 0.5rem;
       font-size: 1rem;
       cursor: pointer;
+    }
+
+    .easy {
+      background-color: #1f5d3e !important;
+    }
+
+    .medium {
+      background-color: #c7791a !important;
+    }
+
+    .hard {
+      background-color: #a92626 !important;
+    }
+
+    .advanced {
+      background-color: #6d28d9 !important;
+    }
+
+    #play-sound {
+      background-color: #facc15;
+      color: #000;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- aplica glassmorphism na seleção de nível
- ajusta cores de cada nível
- deixa a barra de progresso mais clara
- destaca o botão "Repetir Acorde" com amarelo

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d5e853ae883318df9abc8cc03360d