### PR TITLE
Display game instructions first

### DIFF
--- a/percepcao.html
+++ b/percepcao.html
@@ -11,10 +11,10 @@
 <body>
   <nav class="main-nav"><ul><li><a href="index.html">Início</a></li><li><a href="percepcao.html">Percepção</a></li></ul></nav>
   <h1>🎵 Treino de Percepção</h1>
-  <h2>Selecione o nível</h2>
+  <h2 style="display:none;">Selecione o nível</h2>
 
   <div id="intro">
-    <div class="nivel-container">
+    <div class="nivel-container" style="display:none;">
       <div class="seta" id="prev-level">&#9664;</div>
       <div id="nivel-card" class="card-nivel">
         <div id="nivel-badge" class="tag-nivel facil">🎹 Fácil</div>
@@ -36,6 +36,7 @@
           Cada rodada mostra a pontuação (ex: 3/10), um cronômetro 🕒, e você pode repetir o acorde com o botão 🔁.<br />
           Ao final do jogo, seu desempenho será exibido.
         </div>
+        <button id="mostrar-niveis" class="glass-btn">Selecionar nível</button>
       </div>
     </div>
   </div>

--- a/percepcao.js
+++ b/percepcao.js
@@ -52,6 +52,8 @@ let startTime;
 let timerInterval;
 let context;
 let progressEl;
+let nivelContainerEl;
+let nivelHeadingEl;
 
 function getContext() {
   if (!context) {
@@ -170,7 +172,21 @@ function startGame() {
 
 document.addEventListener('DOMContentLoaded', () => {
   progressEl = document.getElementById('timer-progress');
+  nivelContainerEl = document.querySelector('.nivel-container');
+  nivelHeadingEl = document.querySelector('h2');
+  const mostrarNiveisBtn = document.getElementById('mostrar-niveis');
   renderLevel();
+
+  // Exibe apenas as instruções inicialmente
+  if (nivelContainerEl && nivelHeadingEl && mostrarNiveisBtn) {
+    nivelContainerEl.style.display = 'none';
+    nivelHeadingEl.style.display = 'none';
+    mostrarNiveisBtn.addEventListener('click', () => {
+      nivelContainerEl.style.display = 'flex';
+      nivelHeadingEl.style.display = 'block';
+      mostrarNiveisBtn.style.display = 'none';
+    });
+  }
 
   document.getElementById('play-sound').addEventListener('click', () => {
     playChord(currentChord.intervals);
@@ -210,6 +226,12 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('game-area').style.display = 'none';
     document.getElementById('intro').style.display = 'block';
     document.getElementById('end-buttons').style.display = 'none';
+    if (nivelContainerEl && nivelHeadingEl) {
+      nivelContainerEl.style.display = 'flex';
+      nivelHeadingEl.style.display = 'block';
+      const btnMostrar = document.getElementById('mostrar-niveis');
+      if (btnMostrar) btnMostrar.style.display = 'none';
+    }
   });
 
   document.addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- hide the level selector on page load
- add a "Selecionar nível" button under the instructions
- reveal the level selector only after clicking the button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685076313fa4833186c04a15526eaccb